### PR TITLE
feat: 배포 워크플로우에 Discord Embed 알림 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,7 +75,8 @@ jobs:
       - name: Discord 알림 (Success)
         if: success()
         run: |
-          COMMIT_MSG="$(git log -1 --pretty=%B)"
+          SHORT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-7)
+          COMMIT_MSG="${{ github.event.head_commit.message }}"
           curl -H "Content-Type: application/json" \
                -X POST \
                -d "{
@@ -86,8 +87,9 @@ jobs:
                    \"fields\": [
                      { \"name\": \"서비스\", \"value\": \"zipbap-backend\", \"inline\": true },
                      { \"name\": \"상태\", \"value\": \"성공 ✅\", \"inline\": true },
-                     { \"name\": \"Commit SHA\", \"value\": \"\`${{ github.sha.substring(0,7) }}\`\" },
-                     { \"name\": \"Commit 메시지\", \"value\": \"${COMMIT_MSG}\" }
+                     { \"name\": \"Commit SHA\", \"value\": \"\`${SHORT_SHA}\`\" },
+                     { \"name\": \"Commit 메시지\", \"value\": \"${COMMIT_MSG}\" },
+                     { \"name\": \"배포자\", \"value\": \"@${GITHUB_ACTOR}\", \"inline\": true }
                    ],
                    \"footer\": { \"text\": \"GitHub Actions • main 브랜치\" },
                    \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"
@@ -98,19 +100,21 @@ jobs:
       - name: Discord 알림 (Failure)
         if: failure()
         run: |
-          COMMIT_MSG="$(git log -1 --pretty=%B)"
+          SHORT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-7)
+          COMMIT_MSG="${{ github.event.head_commit.message }}"
           curl -H "Content-Type: application/json" \
                -X POST \
                -d "{
                  \"embeds\": [{
                    \"title\": \"❌ 배포 실패\",
-                   \"description\": \"zipbap-api 서비스 배포 중 문제가 발생했습니다.\",
+                   \"description\": \"zipbap-backend 서비스 배포 중 문제가 발생했습니다.\",
                    \"color\": 15158332,
                    \"fields\": [
                      { \"name\": \"서비스\", \"value\": \"zipbap-backend\", \"inline\": true },
                      { \"name\": \"상태\", \"value\": \"실패 ❌\", \"inline\": true },
-                     { \"name\": \"Commit SHA\", \"value\": \"\`${{ github.sha.substring(0,7) }}\`\" },
-                     { \"name\": \"Commit 메시지\", \"value\": \"${COMMIT_MSG}\" }
+                     { \"name\": \"Commit SHA\", \"value\": \"\`${SHORT_SHA}\`\" },
+                     { \"name\": \"Commit 메시지\", \"value\": \"${COMMIT_MSG}\" },
+                     { \"name\": \"배포자\", \"value\": \"@${GITHUB_ACTOR}\", \"inline\": true }
                    ],
                    \"footer\": { \"text\": \"GitHub Actions • main 브랜치\" },
                    \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,15 +75,45 @@ jobs:
       - name: Discord 알림 (Success)
         if: success()
         run: |
+          COMMIT_MSG="$(git log -1 --pretty=%B)"
           curl -H "Content-Type: application/json" \
                -X POST \
-               -d "{\"content\":\"✅ [배포 성공] zipbap-backend 서비스가 정상적으로 배포되었습니다! 🚀 (commit: ${{ github.sha }})\"}" \
+               -d "{
+                 \"embeds\": [{
+                   \"title\": \"✅ 배포 성공\",
+                   \"description\": \"zipbap-backend 서비스가 정상적으로 배포되었습니다! 🚀\",
+                   \"color\": 3066993,
+                   \"fields\": [
+                     { \"name\": \"서비스\", \"value\": \"zipbap-backend\", \"inline\": true },
+                     { \"name\": \"상태\", \"value\": \"성공 ✅\", \"inline\": true },
+                     { \"name\": \"Commit SHA\", \"value\": \"\`${{ github.sha.substring(0,7) }}\`\" },
+                     { \"name\": \"Commit 메시지\", \"value\": \"${COMMIT_MSG}\" }
+                   ],
+                   \"footer\": { \"text\": \"GitHub Actions • main 브랜치\" },
+                   \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"
+                 }]
+               }" \
                ${{ secrets.DISCORD_WEBHOOK_URL }}
 
       - name: Discord 알림 (Failure)
         if: failure()
         run: |
+          COMMIT_MSG="$(git log -1 --pretty=%B)"
           curl -H "Content-Type: application/json" \
                -X POST \
-               -d "{\"content\":\"❌ [배포 실패] zipbap-api 서비스 배포 중 문제가 발생했습니다. (commit: ${{ github.sha }})\"}" \
+               -d "{
+                 \"embeds\": [{
+                   \"title\": \"❌ 배포 실패\",
+                   \"description\": \"zipbap-api 서비스 배포 중 문제가 발생했습니다.\",
+                   \"color\": 15158332,
+                   \"fields\": [
+                     { \"name\": \"서비스\", \"value\": \"zipbap-backend\", \"inline\": true },
+                     { \"name\": \"상태\", \"value\": \"실패 ❌\", \"inline\": true },
+                     { \"name\": \"Commit SHA\", \"value\": \"\`${{ github.sha.substring(0,7) }}\`\" },
+                     { \"name\": \"Commit 메시지\", \"value\": \"${COMMIT_MSG}\" }
+                   ],
+                   \"footer\": { \"text\": \"GitHub Actions • main 브랜치\" },
+                   \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"
+                 }]
+               }" \
                ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,3 +71,19 @@ jobs:
               -e SPRING_PROFILES_ACTIVE=prod \
               -v /home/ubuntu/application-prod.yml:/app/config/application-prod.yml \
               ${{ secrets.DOCKER_USERNAME }}/zipbap-api:latest
+
+      - name: Discord 알림 (Success)
+        if: success()
+        run: |
+          curl -H "Content-Type: application/json" \
+               -X POST \
+               -d "{\"content\":\"✅ [배포 성공] zipbap-backend 서비스가 정상적으로 배포되었습니다! 🚀 (commit: ${{ github.sha }})\"}" \
+               ${{ secrets.DISCORD_WEBHOOK_URL }}
+
+      - name: Discord 알림 (Failure)
+        if: failure()
+        run: |
+          curl -H "Content-Type: application/json" \
+               -X POST \
+               -d "{\"content\":\"❌ [배포 실패] zipbap-api 서비스 배포 중 문제가 발생했습니다. (commit: ${{ github.sha }})\"}" \
+               ${{ secrets.DISCORD_WEBHOOK_URL }}


### PR DESCRIPTION
## 📌 개요
- GitHub Actions 배포 파이프라인에 Discord 알림을 개선  
- 단순 텍스트 → Embed 포맷으로 변경하여 가독성 향상  

## 🔨 변경 사항
- 성공/실패 알림 모두 Embed 카드 형식 적용  
- Commit SHA 7자리 및 Commit 메시지 표시  
- 알림에 배포 브랜치/시간 정보 포함  

## ✅ 테스트
- main 브랜치에 push 시 정상적으로 Discord에 embed 메시지 도착 확인  
- 성공/실패 상황 모두 알림 확인 완료  

<img width="454" height="332" alt="image" src="https://github.com/user-attachments/assets/065f6356-35e3-4ad4-b5ac-1293f3fd7f18" />

