### PR TITLE
[Feat] Swagger 및 공통응답 로직 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,13 @@ dependencies {
 	// JPA & Hibernate
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 
+	// validation
+	implementation("org.springframework.boot:spring-boot-starter-validation")
+
+	// Swagger
+	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0")
+
+
 	// MariaDB Driver (JDBC 연결)
 	runtimeOnly("org.mariadb.jdbc:mariadb-java-client")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 
 	// Swagger
-	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0")
+	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0")
 
 
 	// MariaDB Driver (JDBC 연결)

--- a/src/main/kotlin/zipbap/api/config/SwaggerConfig.kt
+++ b/src/main/kotlin/zipbap/api/config/SwaggerConfig.kt
@@ -1,0 +1,48 @@
+package zipbap.api.config
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.security.SecurityRequirement
+import io.swagger.v3.oas.models.security.SecurityScheme
+import io.swagger.v3.oas.models.servers.Server
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SwaggerConfig {
+
+    @Bean
+    fun openAPI(): OpenAPI {
+        return OpenAPI()
+                .addServersItem(Server().url("http://localhost:8080")) // local용
+                .addServersItem(Server().url("https://zipbap.store")) // 배포 서버용
+                /*
+                    이전 프로젝트에서 ssl 연동시, www 없는 API는 스웨거 사용이 안되는 문제가 있어서
+                    따로 추가하였습니다.
+                 */
+                .addServersItem(Server().url("https://www.zipbap.store"))
+                .components(Components()
+                        .addSecuritySchemes(BEARER_KEY,
+                                SecurityScheme()
+                                        .name(BEARER_KEY)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT") // UI에 표기용
+                        )
+                )
+                .addSecurityItem(SecurityRequirement().addList(BEARER_KEY))
+                .info(apiInfo())
+    }
+
+    private fun apiInfo(): Info {
+        return Info()
+                .title("Zipbap")
+                .description("집밥 스웨거입니다.")
+                .version("1.0.1")
+    }
+
+    companion object {
+        private const val BEARER_KEY = "bearerAuth"
+    }
+}

--- a/src/main/kotlin/zipbap/api/global/ApiResponse.kt
+++ b/src/main/kotlin/zipbap/api/global/ApiResponse.kt
@@ -1,0 +1,32 @@
+package zipbap.api.global
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonPropertyOrder
+import zipbap.api.global.code.BaseCode
+import zipbap.api.global.code.status.SuccessStatus
+
+@JsonPropertyOrder("isSuccess", "code", "message", "result")
+class ApiResponse<T>(
+    val isSuccess: Boolean = false,
+    val code: String? = null,
+    val message: String? = null,
+    @JsonInclude(JsonInclude.Include.NON_NULL) // Null이 아닌 경우에만 포함됩니다.
+    val result: T? = null
+) {
+
+
+    companion object {
+        fun <T> onSuccess(result: T): ApiResponse<T> {
+            return ApiResponse<T>(true, SuccessStatus._OK.code, SuccessStatus._OK.message, result)
+        }
+
+        fun <T> of(code: BaseCode, result: T): ApiResponse<T> {
+            return ApiResponse(true, code.reasonHttpStatus.code, code.reasonHttpStatus.message, result)
+        }
+
+        fun <T> onFailure(code: String?, message: String?, data: T?): ApiResponse<T> {
+            return ApiResponse(false, code, message, data)
+        }
+    }
+}

--- a/src/main/kotlin/zipbap/api/global/code/BaseCode.kt
+++ b/src/main/kotlin/zipbap/api/global/code/BaseCode.kt
@@ -1,0 +1,6 @@
+package zipbap.api.global.code
+
+interface BaseCode {
+    val reasonDto: ReasonDto
+    val reasonHttpStatus: ReasonDto
+}

--- a/src/main/kotlin/zipbap/api/global/code/BaseErrorCode.kt
+++ b/src/main/kotlin/zipbap/api/global/code/BaseErrorCode.kt
@@ -1,0 +1,6 @@
+package zipbap.api.global.code
+
+interface BaseErrorCode {
+    val reason: ErrorReasonDto
+    val reasonHttpStatus: ErrorReasonDto
+}

--- a/src/main/kotlin/zipbap/api/global/code/ErrorReasonDto.kt
+++ b/src/main/kotlin/zipbap/api/global/code/ErrorReasonDto.kt
@@ -1,0 +1,11 @@
+package zipbap.api.global.code
+
+import org.springframework.http.HttpStatus
+
+data class ErrorReasonDto(
+    val httpStatus: HttpStatus,
+    val isSuccess: Boolean,
+    val code: String,
+    val message: String
+) {
+}

--- a/src/main/kotlin/zipbap/api/global/code/ReasonDto.kt
+++ b/src/main/kotlin/zipbap/api/global/code/ReasonDto.kt
@@ -1,0 +1,11 @@
+package zipbap.api.global.code
+
+import org.springframework.http.HttpStatus
+
+data class ReasonDto(
+     val httpStatus: HttpStatus? = null,
+     val isSuccess: Boolean = false,
+     val code: String? = null,
+     val message: String? = null
+) {
+}

--- a/src/main/kotlin/zipbap/api/global/code/status/ErrorStatus.kt
+++ b/src/main/kotlin/zipbap/api/global/code/status/ErrorStatus.kt
@@ -1,0 +1,23 @@
+package zipbap.api.global.code.status
+
+import org.springframework.http.HttpStatus
+import zipbap.api.global.code.BaseErrorCode
+import zipbap.api.global.code.ErrorReasonDto
+
+enum class ErrorStatus(
+        val httpStatus: HttpStatus,
+        val code: String,
+        val message: String
+) : BaseErrorCode {
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "PAYMENT404", "결제 수단을 찾을 수 없습니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다.");
+
+    override val reason: ErrorReasonDto
+        get() = ErrorReasonDto(httpStatus, false, code, message)
+
+    override val reasonHttpStatus: ErrorReasonDto
+        get() = ErrorReasonDto(httpStatus, false, code, message)
+}

--- a/src/main/kotlin/zipbap/api/global/code/status/SuccessStatus.kt
+++ b/src/main/kotlin/zipbap/api/global/code/status/SuccessStatus.kt
@@ -1,0 +1,22 @@
+package zipbap.api.global.code.status
+
+import org.springframework.http.HttpStatus
+import zipbap.api.global.code.BaseCode
+import zipbap.api.global.code.ReasonDto
+
+enum class SuccessStatus(
+        val httpStatus: HttpStatus,
+        val code: String,
+        val message: String
+
+) : BaseCode {
+
+    _OK(HttpStatus.OK, "COMMON100", "성공입니다.");
+
+
+    override val reasonDto: ReasonDto
+        get() = ReasonDto(httpStatus, true, code, message)
+
+    override val reasonHttpStatus: ReasonDto
+        get() = ReasonDto(httpStatus, true, code, message)
+}

--- a/src/main/kotlin/zipbap/api/global/exception/ExceptionAdvice.kt
+++ b/src/main/kotlin/zipbap/api/global/exception/ExceptionAdvice.kt
@@ -1,0 +1,133 @@
+package zipbap.api.global.exception
+
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.validation.ConstraintViolationException
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatusCode
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.FieldError
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.context.request.ServletWebRequest
+import org.springframework.web.context.request.WebRequest
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
+import zipbap.api.global.ApiResponse
+import zipbap.api.global.code.ErrorReasonDto
+import zipbap.api.global.code.status.ErrorStatus
+import java.util.*
+import java.util.function.Consumer
+
+@RestControllerAdvice
+class ExceptionAdvice : ResponseEntityExceptionHandler() {
+
+    /**
+     * @Valid 어노테이션을 통한 검증 실패시 작동하는 메소드입니다.
+     * ConstraintViolationException은 @RequestParam, @PathVariable을 사용한
+     * 파라미터에서 검증 실패시 발생합니다.
+     */
+    @ExceptionHandler
+    fun validation(e: ConstraintViolationException, request: WebRequest): ResponseEntity<Any>? {
+        val errorMessage: String = e.constraintViolations.stream()
+                .map { constraintViolation -> constraintViolation.message }
+                .findFirst()
+                .orElseThrow { RuntimeException("ConstraintViolationException 추출 도중 에러 발생") }
+
+        return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY, request)
+    }
+
+
+    /**
+     * @Valid 어노테이션을 통한 검증 실패시 작동하는 메소드입니다.
+     * MethodArgumentNotValidException는 @RequestBody를 사용한 파라미터에서 검증 실패시 발생합니다.
+     */
+    protected override fun handleMethodArgumentNotValid(
+            ex: MethodArgumentNotValidException, headers: HttpHeaders, status: HttpStatusCode, request: WebRequest): ResponseEntity<Any>? {
+        val errors: MutableMap<String, String> = LinkedHashMap()
+
+        ex.bindingResult.fieldErrors
+                .forEach(Consumer<FieldError> { fieldError: FieldError ->
+                    val fieldName: String = fieldError.field
+                    val errorMessage = Optional.ofNullable<String>(fieldError.defaultMessage).orElse("")
+                    errors.merge(fieldName, errorMessage) { existingErrorMessage: String, newErrorMessage: String -> "$existingErrorMessage, $newErrorMessage" }
+                })
+
+        return handleExceptionInternalArgs(ex, HttpHeaders.EMPTY, ErrorStatus.valueOf("_BAD_REQUEST"), request, errors)
+    }
+
+
+    /**
+     * 일반적으로 Java에서 발생하는 에러 발생시 작동하는 메소드입니다.
+     * ex) IllegalArgumentException
+     */
+    @ExceptionHandler
+    fun exception(e: Exception, request: WebRequest): ResponseEntity<Any>? {
+        e.printStackTrace()
+
+        return handleExceptionInternalFalse(e, ErrorStatus.INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY, ErrorStatus.INTERNAL_SERVER_ERROR.httpStatus, request, e.message)
+    }
+
+    /**
+     * GeneralException이 발생하면 작동하는 메소드입니다.
+     * GeneralException은 특정 자원을 요청했는데 없을 경우 주로 발생시킵니다.
+     * ex) userRepository.findById(id).orElseThrow(::GeneralException)
+     * 주로 개발자가 미리 정의한 ErrorStatus를 담아서 발생합니다.
+     */
+    @ExceptionHandler(value = [GeneralException::class])
+    fun onThrowException(generalException: GeneralException, request: HttpServletRequest): ResponseEntity<Any>? {
+        val errorReasonHttpStatus: ErrorReasonDto = generalException.errorReasonHttpStatus
+        return handleExceptionInternal(generalException, errorReasonHttpStatus, HttpHeaders.EMPTY, request)
+    }
+
+    private fun handleExceptionInternal(e: Exception, reason: ErrorReasonDto,
+                                        headers: HttpHeaders?, request: HttpServletRequest): ResponseEntity<Any>? {
+        val body: ApiResponse<Any> = ApiResponse.onFailure(reason.code, reason.message, null)
+
+        val webRequest: WebRequest = ServletWebRequest(request)
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers ?: HttpHeaders.EMPTY,
+                reason.httpStatus,
+                webRequest
+        )
+    }
+
+    private fun handleExceptionInternalFalse(e: Exception, errorCommonStatus: ErrorStatus,
+                                             headers: HttpHeaders, status: HttpStatus, request: WebRequest, errorPoint: String?): ResponseEntity<Any>? {
+        val body: ApiResponse<Any> = ApiResponse.onFailure(errorCommonStatus.code, errorCommonStatus.message, errorPoint)
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                status,
+                request
+        )
+    }
+
+    private fun handleExceptionInternalArgs(e: Exception, headers: HttpHeaders, errorCommonStatus: ErrorStatus,
+                                            request: WebRequest, errorArgs: Map<String, String>): ResponseEntity<Any>? {
+        val body: ApiResponse<Any> = ApiResponse.onFailure(errorCommonStatus.code, errorCommonStatus.message, errorArgs)
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.httpStatus,
+                request
+        )
+    }
+
+    private fun handleExceptionInternalConstraint(e: Exception, errorCommonStatus: ErrorStatus,
+                                                  headers: HttpHeaders, request: WebRequest): ResponseEntity<Any>? {
+        val body: ApiResponse<Any> = ApiResponse.onFailure(errorCommonStatus.code, errorCommonStatus.message, null)
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.httpStatus,
+                request
+        )
+    }
+}

--- a/src/main/kotlin/zipbap/api/global/exception/GeneralException.kt
+++ b/src/main/kotlin/zipbap/api/global/exception/GeneralException.kt
@@ -1,0 +1,15 @@
+package zipbap.api.global.exception
+
+import zipbap.api.global.code.BaseErrorCode
+import zipbap.api.global.code.ErrorReasonDto
+
+class GeneralException(
+        val code: BaseErrorCode
+) : RuntimeException() {
+
+    val errorReason: ErrorReasonDto
+        get() = this.code.reason
+
+    val errorReasonHttpStatus: ErrorReasonDto
+        get() = this.code.reasonHttpStatus
+}


### PR DESCRIPTION
> ### 📌 작업 내용
> 
> * 공통 응답 로직 추가 (ApiResponse)
> * ControllerAdvice 및 에러 관련 class 추가
> * Gradle 의존성 추가 (Swagger, Validaton)
> * SwaggerConfig 추가

 
> ### 🔍 상세 설명
> 
> * Swagger는 JWT 연동 고려하여 관련 설정도 같이 추가
> * 공통응답은 Controller에서 응답 시, Service에서 나온 데이터에 ApiResponse.onSucess(data) 호출시 사용가능
> * 예외 발생시켜야 하는 경우 GeneralException 던져주면 됨 파라미터로 ErrorStatus에 enum 정의하고 사용
>   ex) userRepository.findById.orElseThrow(GeneralException(ErrorStatus.USER_NOT_FOUND))
> * 기존 다른 프로젝트에서 사용하던 코드 코틀린으로 변환하여 사용했음
 

> ### ✅ 확인 사항
> 
> * [x]    예외 처리 작동 확인
> * [x]   Swagger 접속 및 동작 확인

