### PR TITLE
[feat] : 내 카테고리 CRUD API 추가 및 Recipe/Bookmark/MyCategory ID 전략 변경

### DIFF
--- a/src/main/kotlin/zipbap/app/api/mycategory/controller/MyCategoryController.kt
+++ b/src/main/kotlin/zipbap/app/api/mycategory/controller/MyCategoryController.kt
@@ -1,0 +1,48 @@
+package zipbap.app.api.mycategory.controller
+
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.*
+import zipbap.app.api.mycategory.dto.MyCategoryRequestDto
+import zipbap.app.api.mycategory.dto.MyCategoryResponseDto
+import zipbap.app.api.mycategory.service.MyCategoryService
+import zipbap.app.global.ApiResponse
+
+@RestController
+@RequestMapping("/api/my-categories")
+@Tag(name = "My Categories", description = "내 카테고리 관리 API (개인 사용자 전용)")
+class MyCategoryController(
+    private val myCategoryService: MyCategoryService
+) {
+
+    @PostMapping
+    fun createMyCategory(
+        @RequestBody dto: MyCategoryRequestDto.CreateMyCategoryDto,
+        @RequestParam("userId") userId: Long
+    ): ApiResponse<MyCategoryResponseDto> =
+        ApiResponse.onSuccess(myCategoryService.createMyCategory(dto, userId))
+    // TODO: 추후 JWT 적용 시 userId 파라미터 제거 후, SecurityContext 에서 인증 사용자 정보 추출 예정
+
+    @PutMapping("/{id}")
+    fun updateMyCategory(
+        @PathVariable("id") id: String,
+        @RequestBody dto: MyCategoryRequestDto.UpdateMyCategoryDto,
+        @RequestParam("userId") userId: Long
+    ): ApiResponse<MyCategoryResponseDto> =
+        ApiResponse.onSuccess(myCategoryService.updateMyCategory(id, dto, userId))
+    // TODO: 추후 JWT 적용 시 userId 파라미터 제거 후, SecurityContext 에서 인증 사용자 정보 추출 예정
+
+    @GetMapping
+    fun getMyCategories(
+        @RequestParam("userId") userId: Long
+    ): ApiResponse<List<MyCategoryResponseDto>> =
+        ApiResponse.onSuccess(myCategoryService.getMyCategories(userId))
+    // TODO: 추후 JWT 적용 시 userId 파라미터 제거 후, SecurityContext 에서 인증 사용자 정보 추출 예정
+
+    @DeleteMapping("/{id}")
+    fun deleteMyCategory(
+        @PathVariable("id") id: String,
+        @RequestParam("userId") userId: Long
+    ): ApiResponse<Unit> =
+        ApiResponse.onSuccess(myCategoryService.deleteMyCategory(id, userId))
+    // TODO: 추후 JWT 적용 시 userId 파라미터 제거 후, SecurityContext 에서 인증 사용자 정보 추출 예정
+}

--- a/src/main/kotlin/zipbap/app/api/mycategory/converter/MyCategoryConverter.kt
+++ b/src/main/kotlin/zipbap/app/api/mycategory/converter/MyCategoryConverter.kt
@@ -1,0 +1,30 @@
+package zipbap.app.api.mycategory.converter
+
+import zipbap.app.domain.category.mycategory.MyCategory
+import zipbap.app.api.mycategory.dto.MyCategoryRequestDto
+import zipbap.app.api.mycategory.dto.MyCategoryResponseDto
+import zipbap.app.domain.user.User
+
+object MyCategoryConverter {
+
+    /**
+     * CreateMyCategoryDto -> MyCategoryEntity
+     */
+    fun toEntity(id: String, dto: MyCategoryRequestDto.CreateMyCategoryDto, user: User): MyCategory =
+        MyCategory(id = id, user = user, name = dto.name)
+
+    /**
+     * UpdateMyCategoryDto -> MyCategoryEntity
+     */
+    fun toEntity(id: String, dto: MyCategoryRequestDto.UpdateMyCategoryDto, user: User): MyCategory =
+        MyCategory(id = id, user = user, name = dto.name ?: "")
+
+    /**
+     * MyCategoryEntity -> MyCategoryResponseDto
+     */
+    fun toDto(entity: MyCategory): MyCategoryResponseDto =
+        MyCategoryResponseDto(
+            id = entity.id,
+            name = entity.name,
+        )
+}

--- a/src/main/kotlin/zipbap/app/api/mycategory/dto/MyCategoryRequestDto.kt
+++ b/src/main/kotlin/zipbap/app/api/mycategory/dto/MyCategoryRequestDto.kt
@@ -1,0 +1,23 @@
+package zipbap.app.api.mycategory.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+class MyCategoryRequestDto {
+
+    @Schema(description = "내 카테고리 생성 요청 DTO")
+    data class CreateMyCategoryDto(
+        @field:NotBlank(message = "내 카테고리 이름은 필수 값입니다.")
+        @field:Size(max = 20, message = "내 카테고리 이름은 최대 20자까지 가능합니다.")
+        @Schema(description = "내 카테고리 명칭", example = "다이어트 요리")
+        val name: String,
+    )
+
+    @Schema(description = "내 카테고리 수정 요청 DTO")
+    data class UpdateMyCategoryDto(
+        @field:Size(max = 20, message = "내 카테고리 이름은 최대 20자까지 가능합니다.")
+        @Schema(description = "내 카테고리 명칭", example = "간단한 요리")
+        val name: String?,
+    )
+}

--- a/src/main/kotlin/zipbap/app/api/mycategory/dto/MyCategoryResponseDto.kt
+++ b/src/main/kotlin/zipbap/app/api/mycategory/dto/MyCategoryResponseDto.kt
@@ -1,0 +1,12 @@
+package zipbap.app.api.mycategory.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "내 카테고리 응답 DTO")
+data class MyCategoryResponseDto(
+    @Schema(description = "ID", example = "MC-1-00001")
+    val id: String,
+
+    @Schema(description = "내 카테고리 명칭", example = "다이어트 요리")
+    val name: String,
+)

--- a/src/main/kotlin/zipbap/app/api/mycategory/service/MyCategoryService.kt
+++ b/src/main/kotlin/zipbap/app/api/mycategory/service/MyCategoryService.kt
@@ -1,0 +1,109 @@
+package zipbap.app.api.mycategory.service
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import zipbap.app.api.mycategory.converter.MyCategoryConverter
+import zipbap.app.api.mycategory.dto.MyCategoryRequestDto
+import zipbap.app.api.mycategory.dto.MyCategoryResponseDto
+import zipbap.app.domain.category.mycategory.MyCategory
+import zipbap.app.domain.category.mycategory.MyCategoryRepository
+import zipbap.app.domain.user.User
+import zipbap.app.domain.user.UserRepository
+import zipbap.app.global.code.status.ErrorStatus
+import zipbap.app.global.exception.GeneralException
+import zipbap.app.global.util.CustomIdGenerator
+
+@Service
+@Transactional
+class MyCategoryService(
+    private val myCategoryRepository: MyCategoryRepository,
+    private val userRepository: UserRepository
+) {
+
+    /**
+     * 새로운 내 카테고리를 등록합니다.
+     *
+     * @param dto 새로운 내 카테고리 생성 요청 DTO
+     * @param userId 요청한 사용자 ID (추후 JWT 인증 사용자 기반으로 변경 예정)
+     * @return 생성된 내 카테고리 응답 DTO
+     */
+    fun createMyCategory(dto: MyCategoryRequestDto.CreateMyCategoryDto, userId: Long): MyCategoryResponseDto {
+        // 사용자 미인증 시
+        val user: User = userRepository.findById(userId)
+            .orElseThrow { GeneralException(ErrorStatus.UNAUTHORIZED) }
+
+        // 이미 존재하는 '내 카테고리'일 경우
+        if (myCategoryRepository.existsByUserIdAndName(userId, dto.name)) {
+            throw GeneralException(ErrorStatus.DUPLICATE_CATEGORY)
+        }
+
+        // 사용자별 카테고리 수 → 다음 시퀀스
+        val seq = myCategoryRepository.countByUserId(userId) + 1
+        val id = CustomIdGenerator.generate("MC", userId, seq)
+
+        val entity = MyCategory(id = id, user = user, name = dto.name)
+        return MyCategoryConverter.toDto(myCategoryRepository.save(entity))
+    }
+
+    /**
+     * 특정 ID의 내 카테고리를 수정합니다.
+     *
+     * @param id 수정할 내 카테고리 ID
+     * @param dto 내 카테고리 수정 요청 DTO
+     * @param userId 요청한 사용자 ID (추후 JWT 인증 사용자 기반으로 변경 예정)
+     * @return 수정된 내 카테고리 응답 DTO
+     */
+    fun updateMyCategory(id: String, dto: MyCategoryRequestDto.UpdateMyCategoryDto, userId: Long): MyCategoryResponseDto {
+        // 해당 ID의 '내 카테고리'가 존재하지 않을 경우
+        val entity = myCategoryRepository.findById(id)
+            .orElseThrow { GeneralException(ErrorStatus.CATEGORY_NOT_FOUND) }
+
+        // 다른 사용자가 소유한 카테고리 수정 시도
+        if (entity.user.id != userId) {
+            throw GeneralException(ErrorStatus.FORBIDDEN)
+        }
+
+        // 사용자 미인증 시
+        val user: User = userRepository.findById(userId)
+            .orElseThrow { GeneralException(ErrorStatus.UNAUTHORIZED) }
+
+        val updated = MyCategory(id = entity.id, user = user, name = dto.name ?: "")
+        return MyCategoryConverter.toDto(myCategoryRepository.save(updated))
+    }
+
+    /**
+     * 특정 사용자의 모든 내 카테고리를 조회합니다.
+     *
+     * @param userId 요청한 사용자 ID (추후 JWT 인증 사용자 기반으로 변경 예정)
+     * @return 해당 사용자의 내 카테고리 응답 DTO 리스트
+     */
+    @Transactional(readOnly = true)
+    fun getMyCategories(userId: Long): List<MyCategoryResponseDto> {
+        // 사용자 미인증 시
+        val user: User = userRepository.findById(userId)
+            .orElseThrow { GeneralException(ErrorStatus.UNAUTHORIZED) }
+
+        return myCategoryRepository.findAll()
+            .filter { it.user.id == user.id }
+            .map(MyCategoryConverter::toDto)
+    }
+
+    /**
+     * 특정 ID의 내 카테고리를 삭제합니다.
+     *
+     * @param id 삭제할 내 카테고리 ID
+     * @param userId 요청한 사용자 ID (추후 JWT 인증 사용자 기반으로 변경 예정)
+     */
+    fun deleteMyCategory(id: String, userId: Long) {
+        // 해당 ID의 '내 카테고리'가 존재하지 않을 경우
+        val entity = myCategoryRepository.findById(id)
+            .orElseThrow { GeneralException(ErrorStatus.CATEGORY_NOT_FOUND) }
+
+        // 다른 사용자가 소유한 카테고리 삭제 시도
+        if (entity.user.id != userId) {
+            throw GeneralException(ErrorStatus.FORBIDDEN)
+        }
+
+        myCategoryRepository.deleteById(id)
+    }
+}

--- a/src/main/kotlin/zipbap/app/domain/bookmark/Bookmark.kt
+++ b/src/main/kotlin/zipbap/app/domain/bookmark/Bookmark.kt
@@ -23,7 +23,7 @@ class Bookmark(
         val recipe: Recipe,
 
         @Id
-        @GeneratedValue(strategy = GenerationType.IDENTITY)
-        val id: Long? = null
+        @Column(name = "id", length = 40)
+        val id: String, // BM-{userId}-{sequence}
 ) : BaseEntity() {
 }

--- a/src/main/kotlin/zipbap/app/domain/category/mycategory/MyCategory.kt
+++ b/src/main/kotlin/zipbap/app/domain/category/mycategory/MyCategory.kt
@@ -19,8 +19,8 @@ class MyCategory(
         var name: String,
 
         @Id
-        @GeneratedValue(strategy = GenerationType.IDENTITY)
-        val id: Long? = null
+        @Column(name = "id", length = 30)
+        val id: String
 
 ) : BaseEntity() {
 }

--- a/src/main/kotlin/zipbap/app/domain/category/mycategory/MyCategory.kt
+++ b/src/main/kotlin/zipbap/app/domain/category/mycategory/MyCategory.kt
@@ -20,7 +20,7 @@ class MyCategory(
 
         @Id
         @Column(name = "id", length = 30)
-        val id: String
+        val id: String // MC-{userId}-{sequence}
 
 ) : BaseEntity() {
 }

--- a/src/main/kotlin/zipbap/app/domain/category/mycategory/MyCategoryRepository.kt
+++ b/src/main/kotlin/zipbap/app/domain/category/mycategory/MyCategoryRepository.kt
@@ -1,0 +1,8 @@
+package zipbap.app.domain.category.mycategory
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MyCategoryRepository : JpaRepository<MyCategory, String> {
+    fun existsByUserIdAndName(userId: Long, name: String): Boolean
+    fun countByUserId(userId: Long): Long
+}

--- a/src/main/kotlin/zipbap/app/domain/recipe/Recipe.kt
+++ b/src/main/kotlin/zipbap/app/domain/recipe/Recipe.kt
@@ -80,8 +80,9 @@ class Recipe(
         @Column(name = "recipe_status", nullable = false)
         var recipeStatus: RecipeStatus,
 
+
         @Id
-        @GeneratedValue(strategy = GenerationType.IDENTITY)
-        val id: Long? = null
+        @Column(name = "id", length = 40)
+        val id: String,  // RC-{userId}-{sequence}
 ) : BaseEntity() {
 }

--- a/src/main/kotlin/zipbap/app/domain/user/UserRepository.kt
+++ b/src/main/kotlin/zipbap/app/domain/user/UserRepository.kt
@@ -1,0 +1,17 @@
+package zipbap.app.domain.user
+
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.Optional
+
+interface UserRepository : JpaRepository<User, Long> {
+
+    /**
+     * 이메일로 사용자 존재 여부 확인
+     */
+    fun existsByEmail(email: String): Boolean
+
+    /**
+     * 이메일로 사용자 조회
+     */
+    fun findByEmail(email: String): Optional<User>
+}

--- a/src/main/kotlin/zipbap/app/global/code/status/ErrorStatus.kt
+++ b/src/main/kotlin/zipbap/app/global/code/status/ErrorStatus.kt
@@ -41,7 +41,11 @@ enum class ErrorStatus(
 
     // 요리 난이도
     LEVEL_NOT_FOUND(HttpStatus.NOT_FOUND, "LEVEL404", "해당 난이도를 찾을 수 없습니다."),
-    DUPLICATE_LEVEL(HttpStatus.CONFLICT, "LEVEL409", "이미 존재하는 난이도입니다.");
+    DUPLICATE_LEVEL(HttpStatus.CONFLICT, "LEVEL409", "이미 존재하는 난이도입니다."),
+
+    // 내 카테고리 (사용자 전용 카테고리)
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY404", "해당 '내 카테고리'를 찾을 수 없습니다."),
+    DUPLICATE_CATEGORY(HttpStatus.CONFLICT, "CATEGORY409", "이미 존재하는 '내 카테고리'입니다.");
 
     override val reason: ErrorReasonDto
         get() = ErrorReasonDto(httpStatus, false, code, message)

--- a/src/main/kotlin/zipbap/app/global/util/CustomIdGenerator.kt
+++ b/src/main/kotlin/zipbap/app/global/util/CustomIdGenerator.kt
@@ -1,0 +1,15 @@
+package zipbap.app.global.util
+
+object CustomIdGenerator {
+
+    /**
+     * 도메인별 prefix + userId + sequence 로 ID 생성
+     *
+     * @param prefix 도메인 구분용 접두어 (예: "MC", "RC")
+     * @param userId 사용자 ID
+     * @param sequence 순번 (0-padding 5자리)
+     */
+    fun generate(prefix: String, userId: Long, sequence: Long): String {
+        return "$prefix-$userId-${sequence.toString().padStart(5, '0')}"
+    }
+}


### PR DESCRIPTION
## 📌 개요
이번 PR에서는 두 가지 주요 작업을 진행했습니다.  
1. **MyCategory CRUD API 개발**  
2. **Recipe, Bookmark, MyCategory 엔티티의 ID 전략 변경 (AUTO_INCREMENT → CustomIdGenerator)**  

---

## 🔨 변경 사항 (What)
### 1. MyCategory CRUD API
- 사용자가 자신의 카테고리를 **생성, 조회, 수정, 삭제** 가능
- 추후 **JWT 인증**과 연계해 보안 강화 예정

### 2. 엔티티 ID 전략 변경
- 기존 `Long 기반 AUTO_INCREMENT` → **문자열 기반 CustomIdGenerator**
- 도메인별 ID 패턴 정의
  - Recipe: `RC-{userId}-{sequence}`
  - Bookmark: `BM-{userId}-{sequence}`
  - MyCategory: `MC-{userId}-{sequence}`
- Repository: `countByUserId` 메서드 추가
- Service: `CustomIdGenerator` 활용
- 개발 환경: `ddl-auto: create-drop` 설정으로 스키마 재생성 후 반영

---

## 🤔 변경 이유 (Why)
- `AUTO_INCREMENT`는 단순 증가값이라 **의미 전달력이 부족**하고, 단순 증분 공격에 취약
- `CustomIdGenerator` 적용 효과:
  1. API 응답/운영 툴에서 **ID 가독성 및 추적성 향상**
  2. 사용자별 데이터 흐름 파악 용이  
     (예: `RC-42-00015` → `42번 유저의 15번째 레시피`)
  3. **ID 마스킹 효과**로 보안성 강화

---

## 📌 다른 도메인 제외 이유
- **Follow**: `(follower, following)` 복합 유니크 제약으로 충분  
- **RecipeLike**: `(userId, recipeId)` 복합 유니크 제약으로 충분  
- **Comment**: 대규모 트리 구조 탐색 성능상 `Long PK` 유지가 안정적  
- **User**: 여러 도메인에서 참조되는 루트 엔티티 → PK 변경 시 파급 효과 큼  
  → 현재는 `Long PK` 유지 (필요 시 단계적 변경 고려)

---

## ⚠️ 주의사항
- 기존 DB 스키마와 **호환 불가** → 로컬 DB 초기화 필요  
- PR 반영 후 서버 실행 시 오류 발생 가능  
  - 반드시 `ddl-auto: create-drop` 설정 또는 DB drop 후 실행  
