### PR TITLE
[feat] : 파일 상태 관리 리팩토링 (UNTRACKED 도입)

### DIFF
--- a/src/main/kotlin/zipbap/app/api/file/controller/FileController.kt
+++ b/src/main/kotlin/zipbap/app/api/file/controller/FileController.kt
@@ -4,18 +4,27 @@ import org.springframework.web.bind.annotation.RestController
 import zipbap.app.api.file.docs.FileDocs
 import zipbap.app.api.file.dto.PresignedUrlDto
 import zipbap.app.api.file.service.PresignedUrlProvider
-import java.util.*
+import zipbap.app.domain.file.FileEntity
+import zipbap.app.domain.file.FileRepository
+import zipbap.app.domain.file.FileStatus
+import org.springframework.transaction.annotation.Transactional
 
 @RestController
 class FileController(
-    private val presignedUrlProvider: PresignedUrlProvider
+    private val presignedUrlProvider: PresignedUrlProvider,
+    private val fileRepository: FileRepository
 ) : FileDocs {
 
+    @Transactional
     override fun generatePresignedUrl(
         request: PresignedUrlDto.PresignedUrlRequest
     ): PresignedUrlDto.PresignedUrlResponse {
-        val key = "${request.dirName}/${UUID.randomUUID()}-${request.fileName}"
-        val result = presignedUrlProvider.generateUploadUrl(key)
+        val userId = 1L // TODO: JWT 적용 후 SecurityContext에서 추출
+        val result = presignedUrlProvider.generateUploadUrl(userId, request.fileName)
+
+        // DB에 TEMPORARY_UPLOAD 기록
+        fileRepository.save(FileEntity(fileUrl = result["fileUrl"]!!, status = FileStatus.TEMPORARY_UPLOAD))
+
         return PresignedUrlDto.PresignedUrlResponse(
             uploadUrl = result["uploadUrl"]!!,
             fileUrl = result["fileUrl"]!!

--- a/src/main/kotlin/zipbap/app/api/file/dto/PresignedUrlDto.kt
+++ b/src/main/kotlin/zipbap/app/api/file/dto/PresignedUrlDto.kt
@@ -2,21 +2,18 @@ package zipbap.app.api.file.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-object PresignedUrlDto {
+class PresignedUrlDto {
 
     data class PresignedUrlRequest(
-        @Schema(description = "파일명", example = "step1.jpg")
-        val fileName: String,
-
-        @Schema(description = "저장 디렉토리", example = "recipes/temp")
-        val dirName: String
+        @Schema(description = "파일명", example = "food.png")
+        val fileName: String
     )
 
     data class PresignedUrlResponse(
-        @Schema(description = "S3 업로드에 사용할 Presigned URL")
+        @Schema(description = "업로드용 Presigned URL")
         val uploadUrl: String,
 
-        @Schema(description = "업로드 완료 후 접근 가능한 파일 URL")
+        @Schema(description = "업로드된 파일 접근 URL")
         val fileUrl: String
     )
 }

--- a/src/main/kotlin/zipbap/app/api/recipe/controller/RecipeController.kt
+++ b/src/main/kotlin/zipbap/app/api/recipe/controller/RecipeController.kt
@@ -29,7 +29,7 @@ class RecipeController(
     override fun finalizeRecipe(
         recipeId: String,
         userId: Long,
-        request: RecipeRequestDto.finalizeRecipeRequestDto
+        request: RecipeRequestDto.FinalizeRecipeRequestDto
     ): ApiResponse<RecipeResponseDto.RecipeDetailResponseDto> =
         ApiResponse.onSuccess(recipeService.finalizeRecipe(recipeId, userId, request))
     // TODO: 추후 JWT 적용 시 userId 파라미터 제거 후, SecurityContext 에서 인증 사용자 정보 추출 예정

--- a/src/main/kotlin/zipbap/app/api/recipe/converter/RecipeConverter.kt
+++ b/src/main/kotlin/zipbap/app/api/recipe/converter/RecipeConverter.kt
@@ -37,7 +37,7 @@ object RecipeConverter {
     fun toEntity(
         id: String,
         user: User,
-        dto: RecipeRequestDto.finalizeRecipeRequestDto,
+        dto: RecipeRequestDto.FinalizeRecipeRequestDto,
         myCategory: MyCategory?,
         cookingType: CookingType,
         situation: Situation,
@@ -73,7 +73,7 @@ object RecipeConverter {
      */
     fun toEntityFromRegister(
         recipe: Recipe,
-        orders: List<RecipeRequestDto.finalizeRecipeRequestDto.CookingOrderRequest>
+        orders: List<RecipeRequestDto.FinalizeRecipeRequestDto.CookingOrderRequest>
     ): List<CookingOrder> =
         orders.sortedBy { it.turn }
             .map {

--- a/src/main/kotlin/zipbap/app/api/recipe/docs/RecipeDocs.kt
+++ b/src/main/kotlin/zipbap/app/api/recipe/docs/RecipeDocs.kt
@@ -70,7 +70,7 @@ interface RecipeDocs {
     fun finalizeRecipe(
         @PathVariable("recipeId") recipeId: String,
         @RequestParam("userId") userId: Long,
-        @RequestBody request: RecipeRequestDto.finalizeRecipeRequestDto
+        @RequestBody request: RecipeRequestDto.FinalizeRecipeRequestDto
     ): ApiResponse<RecipeResponseDto.RecipeDetailResponseDto>
 
 

--- a/src/main/kotlin/zipbap/app/api/recipe/dto/RecipeRequestDto.kt
+++ b/src/main/kotlin/zipbap/app/api/recipe/dto/RecipeRequestDto.kt
@@ -11,7 +11,7 @@ object RecipeRequestDto {
      * 레시피 최종 등록 요청 DTO
      * 모든 필드 필수
      */
-    data class finalizeRecipeRequestDto(
+    data class FinalizeRecipeRequestDto(
 
         @Schema(description = "레시피 제목", example = "소고기 미역국", required = true)
         val title: String,

--- a/src/main/kotlin/zipbap/app/domain/file/FileEntity.kt
+++ b/src/main/kotlin/zipbap/app/domain/file/FileEntity.kt
@@ -1,0 +1,24 @@
+package zipbap.app.domain.file
+
+import jakarta.persistence.*
+import zipbap.app.domain.base.BaseEntity
+import zipbap.app.domain.recipe.Recipe
+
+@Entity
+@Table(name = "file")
+class FileEntity(
+
+    @Column(nullable = false)
+    val fileUrl: String, // S3 접근 가능한 전체 URL
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 50, nullable = false)
+    var status: FileStatus = FileStatus.TEMPORARY_UPLOAD,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recipe_id")
+    var recipe: Recipe? = null,
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null
+) : BaseEntity()

--- a/src/main/kotlin/zipbap/app/domain/file/FileRepository.kt
+++ b/src/main/kotlin/zipbap/app/domain/file/FileRepository.kt
@@ -1,0 +1,10 @@
+package zipbap.app.domain.file
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface FileRepository : JpaRepository<FileEntity, Long> {
+    fun findByFileUrl(fileUrl: String): FileEntity?
+
+    // Recipe ID 기준으로 파일 목록 조회
+    fun findAllByRecipeId(recipeId: String): List<FileEntity>
+}

--- a/src/main/kotlin/zipbap/app/domain/file/FileStatus.kt
+++ b/src/main/kotlin/zipbap/app/domain/file/FileStatus.kt
@@ -1,0 +1,13 @@
+package zipbap.app.domain.file
+
+/**
+ * 파일의 저장 상태
+ * - TEMPORARY_UPLOAD : Presigned URL 업로드 완료, 레시피에 연결되지 않은 상태
+ * - FINALIZED        : 레시피에 연결된 최종 저장 상태
+ * - UNTRACKED        : 추적 불가 (DB에 연결 정보가 없거나, 레시피와 무관하게 업로드된 상태)
+ */
+enum class FileStatus {
+    TEMPORARY_UPLOAD,
+    FINALIZED,
+    UNTRACKED
+}


### PR DESCRIPTION

- FileStatus Enum에 UNTRACKED 상태 추가
  - TEMPORARY_UPLOAD: 임시 저장
  - FINALIZED: 최종 저장
  - UNTRACKED: 레시피에서 참조되지 않는 파일

- RecipeService
  - updateTempRecipe: 사용되지 않는 파일을 UNTRACKED 처리
  - finalizeRecipe: 최종 저장 시 참조되지 않는 파일을 UNTRACKED 처리
  - 공통 로직을 updateFileStatuses() 메서드로 분리

- FileRepository
  - findAllByRecipeId() 추가 (레시피 단위 파일 조회 지원)

- 서비스 흐름 정리
  1) Presigned URL 업로드 → TEMPORARY_UPLOAD
  2) 임시 저장/최종 저장 → 참조된 파일만 유지, 나머지는 UNTRACKED 처리
  3) UNTRACKED 파일은 후속 배치 작업에서 DB/S3에서 실제 삭제 예정

- 추후 배치 시스템 도입 예정
  - UNTRACKED 파일 자동 정리 배치 작업 추가 계획
