### PR TITLE
[feat] : JWT 기반 인증 적용 및 레시피 기능 확장(auth, recipe)

### DIFF
--- a/src/main/kotlin/zipbap/app/admin/auth/controller/AuthAdminController.kt
+++ b/src/main/kotlin/zipbap/app/admin/auth/controller/AuthAdminController.kt
@@ -7,7 +7,10 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import zipbap.app.api.auth.domain.token.service.TokenService
 import zipbap.app.api.user.service.UserService
+import zipbap.app.domain.user.UserRepository
 import zipbap.app.global.ApiResponse
+import zipbap.app.global.code.status.ErrorStatus
+import zipbap.app.global.exception.GeneralException
 
 /**
  * 테스트 용도로 사용할 계정 생성하기 위해 만든 class
@@ -17,7 +20,8 @@ import zipbap.app.global.ApiResponse
 @RequestMapping("/admin/auth")
 class AuthAdminController(
         private val userService: UserService,
-        private val tokenService: TokenService
+        private val tokenService: TokenService,
+        private val userRepository: UserRepository
 ) {
 
     @PostMapping("/user")
@@ -28,8 +32,12 @@ class AuthAdminController(
     }
 
     @GetMapping("/access-token")
-    fun getAccessToken(@RequestParam email: String) =
-        ApiResponse.onSuccess(tokenService.generateAccessToken(email))
+    fun getAccessToken(@RequestParam email: String): ApiResponse<String> {
+        val user = userRepository.findByEmail(email).orElseThrow {
+            GeneralException(ErrorStatus.USER_NOT_FOUND)
+        }
+        return ApiResponse.onSuccess(tokenService.generateAccessToken(user))
+    }
 
 
 

--- a/src/main/kotlin/zipbap/app/api/auth/JwtTokenProvider.kt
+++ b/src/main/kotlin/zipbap/app/api/auth/JwtTokenProvider.kt
@@ -5,26 +5,22 @@ import io.jsonwebtoken.security.Keys
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.security.core.Authentication
-import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.stereotype.Component
-import zipbap.app.api.auth.service.CustomUserDetailsService
+import zipbap.app.domain.user.User
 import java.util.*
 import javax.crypto.SecretKey
 
-// made by claude
 @Component
 class JwtTokenProvider(
-        @Value("\${spring.security.jwt.secret}")
+    @Value("\${spring.security.jwt.secret}")
     private val jwtSecret: String,
 
-        @Value("\${spring.security.jwt.expiration}") // 24시간
+    @Value("\${spring.security.jwt.expiration}")
     private val jwtExpirationMs: Long,
 
-        @Value("\${spring.security.jwt.refresh-expiration}") // 7일
+    @Value("\${spring.security.jwt.refresh-expiration}")
     private val refreshTokenExpirationMs: Long
 ) {
-
 
     private val signingKey: SecretKey by lazy {
         val decoded = try {
@@ -37,77 +33,71 @@ class JwtTokenProvider(
 
     private val jwtParser: JwtParser by lazy {
         Jwts.parserBuilder()
-                .setSigningKey(signingKey)
-                .setAllowedClockSkewSeconds(60)
-                .build()
+            .setSigningKey(signingKey)
+            .setAllowedClockSkewSeconds(60)
+            .build()
     }
 
     /**
-     * 액세스 토큰 생성
+     * 액세스 토큰 생성 (userId + email)
      */
-    fun generateAccessToken(authentication: Authentication): String {
-        val userPrincipal: UserDetails = authentication.principal as UserDetails
-        return generateAccessToken(userPrincipal.getUsername())
-    }
-
-    fun generateAccessToken(email: String): String {
+    fun generateAccessToken(user: User): String {
         val expiryDate = Date(System.currentTimeMillis() + jwtExpirationMs)
 
         return Jwts.builder()
-                .setSubject(email)
-                .setIssuedAt(Date())
-                .setExpiration(expiryDate)
-                .claim("type", "access")
-                .signWith(signingKey, SignatureAlgorithm.HS512)
-                .compact()
+            .setSubject(user.id.toString())
+            .claim("email", user.email)
+            .setIssuedAt(Date())
+            .setExpiration(expiryDate)
+            .claim("type", "access")
+            .signWith(signingKey, SignatureAlgorithm.HS512)
+            .compact()
     }
 
     /**
-     * 리프레시 토큰 생성
+     * 리프레시 토큰 생성 (userId만)
      */
-    fun generateRefreshToken(email: String): String {
+    fun generateRefreshToken(user: User): String {
         val expiryDate = Date(System.currentTimeMillis() + refreshTokenExpirationMs)
 
         return Jwts.builder()
-                .setSubject(email)
-                .setIssuedAt(Date())
-                .setExpiration(expiryDate)
-                .claim("type", "refresh")
-                .signWith(signingKey, SignatureAlgorithm.HS512)
-                .compact()
+            .setSubject(user.id.toString())
+            .setIssuedAt(Date())
+            .setExpiration(expiryDate)
+            .claim("type", "refresh")
+            .signWith(signingKey, SignatureAlgorithm.HS512)
+            .compact()
     }
 
     /**
-     * 토큰에서 사용자명 추출
+     * 토큰에서 userId(Long) 추출
      */
-    fun getUsernameFromToken(token: String): String =
-            parseClaims(token).subject
+    fun getUserIdFromToken(token: String): Long =
+        parseClaims(token).subject.toLong()
+
+    /**
+     * 토큰에서 email 추출 (optional)
+     */
+    fun getEmailFromToken(token: String): String? =
+        parseClaims(token).get("email", String::class.java)
 
     /**
      * 토큰 유효성 검증
      */
     fun validateToken(token: String?): Boolean {
         return try {
-            Jwts.parserBuilder()
-                    .setSigningKey(signingKey)
-                    .build()
-                    .parseClaimsJws(token)
+            jwtParser.parseClaimsJws(token)
             true
         } catch (ex: SecurityException) {
-            logger.error("Invalid JWT signature: {}", ex.message)
-            false
+            logger.error("Invalid JWT signature: {}", ex.message); false
         } catch (ex: MalformedJwtException) {
-            logger.error("Invalid JWT token: {}", ex.message)
-            false
+            logger.error("Invalid JWT token: {}", ex.message); false
         } catch (ex: ExpiredJwtException) {
-            logger.error("Expired JWT token: {}", ex.message)
-            false
+            logger.error("Expired JWT token: {}", ex.message); false
         } catch (ex: UnsupportedJwtException) {
-            logger.error("Unsupported JWT token: {}", ex.message)
-            false
+            logger.error("Unsupported JWT token: {}", ex.message); false
         } catch (ex: IllegalArgumentException) {
-            logger.error("JWT claims string is empty: {}", ex.message)
-            false
+            logger.error("JWT claims string is empty: {}", ex.message); false
         }
     }
 
@@ -115,25 +105,13 @@ class JwtTokenProvider(
      * 토큰 타입 확인 (access/refresh)
      */
     fun getTokenType(token: String): String =
-            parseClaims(token).get("type", String::class.java)
+        parseClaims(token).get("type", String::class.java)
 
-
-    /**
-     * 토큰 만료시간 확인
-     */
-    fun getExpirationDateFromToken(token: String): Date =
-            parseClaims(token).expiration
-
-    fun isAccess(token: String): Boolean {
-        return getTokenType(token) == "access"
-    }
-
-    fun isRefresh(token: String): Boolean {
-        return getTokenType(token) == "refresh"
-    }
+    fun isAccess(token: String): Boolean = getTokenType(token) == "access"
+    fun isRefresh(token: String): Boolean = getTokenType(token) == "refresh"
 
     private fun parseClaims(token: String): Claims =
-            jwtParser.parseClaimsJws(token).body
+        jwtParser.parseClaimsJws(token).body
 
     companion object {
         private val logger: Logger = LoggerFactory.getLogger(JwtTokenProvider::class.java)

--- a/src/main/kotlin/zipbap/app/api/auth/domain/token/service/TokenService.kt
+++ b/src/main/kotlin/zipbap/app/api/auth/domain/token/service/TokenService.kt
@@ -18,107 +18,112 @@ import java.security.MessageDigest
 @Service
 @Transactional(readOnly = true)
 class TokenService(
-        private val userRepository: UserRepository,
-
-        private val refreshTokenRepository: RefreshTokenRepository,
-
-        private val jwtTokenProvider: JwtTokenProvider,
-
-        private val customUserDetailsService: CustomUserDetailsService,
-
-        private val refreshHmac: RefreshHmac
+    private val userRepository: UserRepository,
+    private val refreshTokenRepository: RefreshTokenRepository,
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val customUserDetailsService: CustomUserDetailsService,
+    private val refreshHmac: RefreshHmac
 ) {
 
-
     /**
-     * validate 전에 Bearer 파싱이 되어서 들어온다고 가정한다.
+     * Refresh Token 유효성 검증
      */
     fun validateRefreshToken(refreshToken: String): Boolean {
         if (!jwtTokenProvider.isRefresh(refreshToken) || !jwtTokenProvider.validateToken(refreshToken)) {
             throw GeneralException(ErrorStatus.INVALID_TOKEN)
         }
 
-        val email: String = jwtTokenProvider.getUsernameFromToken(refreshToken)
-        val user: User = userRepository.findByEmail(email).orElseThrow {throw GeneralException(ErrorStatus.USER_NOT_FOUND)}
+        val userId: Long = jwtTokenProvider.getUserIdFromToken(refreshToken)
+        val user: User = userRepository.findById(userId).orElseThrow {
+            throw GeneralException(ErrorStatus.USER_NOT_FOUND)
+        }
 
-        val stored = refreshTokenRepository.findByUser(user)
-                ?: return false
+        val stored = refreshTokenRepository.findByUser(user) ?: return false
 
         val hashedRefreshToken = refreshHmac.hmacBase64Url(refreshToken)
         return constantTimeEquals(stored.refreshToken, hashedRefreshToken)
     }
 
+    /**
+     * Access Token 유효성 검증
+     */
     fun validateAccessToken(accessToken: String): Boolean {
         return jwtTokenProvider.validateToken(accessToken) && jwtTokenProvider.isAccess(accessToken)
     }
 
-    fun generateAccessToken(email: String): String {
-        require(email.isNotBlank()) { "이메일은 비어있으면 안됩니다. "}
-
-        return jwtTokenProvider.generateAccessToken(email)
+    /**
+     * Access Token 생성
+     */
+    fun generateAccessToken(user: User): String {
+        return jwtTokenProvider.generateAccessToken(user)
     }
 
+    /**
+     * Authentication 객체 생성
+     */
     fun authenticationToken(token: String): UsernamePasswordAuthenticationToken {
-        require(token.isNotBlank()) { "토큰은 비어있으면 안됩니다. "}
+        require(token.isNotBlank()) { "토큰은 비어있으면 안됩니다." }
 
         if (!validateAccessToken(token)) {
             throw GeneralException(ErrorStatus.INVALID_TOKEN)
         }
 
-        val email: String = jwtTokenProvider.getUsernameFromToken(token)
-        val userDetails: UserDetails = customUserDetailsService.loadUserByUsername(email)
+        val userId: Long = jwtTokenProvider.getUserIdFromToken(token)
+        val user: User = userRepository.findById(userId).orElseThrow {
+            throw GeneralException(ErrorStatus.USER_NOT_FOUND)
+        }
 
-        return UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities())
+        val userDetails: UserDetails = customUserDetailsService.loadUserByUsername(user.email)
+
+        return UsernamePasswordAuthenticationToken(userDetails, null, userDetails.authorities)
     }
 
-
+    /**
+     * Refresh Token 검증 후 Access Token 재발급
+     */
     fun reissueAccessToken(token: String): String {
-        require(token.isNotBlank()) { "토큰은 비어있으면 안됩니다. "}
-
+        require(token.isNotBlank()) { "토큰은 비어있으면 안됩니다." }
 
         if (!validateRefreshToken(token)) {
             throw GeneralException(ErrorStatus.INVALID_TOKEN)
         }
-        val email = jwtTokenProvider.getUsernameFromToken(token)
-        return jwtTokenProvider.generateAccessToken(email)
-    }
 
-    /**
-     * RefreshToken을 생성하는 메소드입니다.
-     * DB에는 토큰을 Hash로 저장, return은 원본
-     */
-    @Transactional
-    fun generateRefreshToken(email: String): String {
-        require(email.isNotBlank()) { "이메일은 비어있으면 안됩니다. "}
-
-        val refreshToken: String = jwtTokenProvider.generateRefreshToken(email)
-        val user: User = userRepository.findByEmail(email).orElseThrow {
+        val userId: Long = jwtTokenProvider.getUserIdFromToken(token)
+        val user: User = userRepository.findById(userId).orElseThrow {
             throw GeneralException(ErrorStatus.USER_NOT_FOUND)
         }
 
+        return jwtTokenProvider.generateAccessToken(user)
+    }
+
+    /**
+     * Refresh Token 생성 및 저장
+     * - DB에는 해시 저장
+     * - 클라이언트에는 원본 반환
+     */
+    @Transactional
+    fun generateRefreshToken(user: User): String {
+        val refreshToken: String = jwtTokenProvider.generateRefreshToken(user)
 
         val hashedRefreshToken = refreshHmac.hmacBase64Url(refreshToken)
         refreshTokenRepository.findByUser(user)
-                ?. let {userRefresh ->
-                    userRefresh.updateToken(hashedRefreshToken)
-                    refreshTokenRepository.save(userRefresh)
-                } ?: refreshTokenRepository.save(RefreshToken.createRefreshToken(user, hashedRefreshToken))
+            ?.let { userRefresh ->
+                userRefresh.updateToken(hashedRefreshToken)
+                refreshTokenRepository.save(userRefresh)
+            } ?: refreshTokenRepository.save(RefreshToken.createRefreshToken(user, hashedRefreshToken))
 
         return refreshToken
     }
 
     companion object {
-
         /**
-         * 상수시간 비교(길이가 다르면 false, 길이가 같으면 바이트 단위 XOR 누적)
-         * JDK 내장: MessageDigest.isEqual(a, b) 사용도 가능
+         * 상수시간 비교
          */
         fun constantTimeEquals(a: String?, b: String?): Boolean {
             if (a == null || b == null) return false
             val aBytes = a.toByteArray(Charsets.UTF_8)
             val bBytes = b.toByteArray(Charsets.UTF_8)
             if (aBytes.size != bBytes.size) return false
-
             return MessageDigest.isEqual(aBytes, bBytes)
         }
     }

--- a/src/main/kotlin/zipbap/app/api/category/controller/CategoryController.kt
+++ b/src/main/kotlin/zipbap/app/api/category/controller/CategoryController.kt
@@ -1,6 +1,8 @@
 package zipbap.app.api.category.controller
 
+import zipbap.app.domain.user.User
 import org.springframework.web.bind.annotation.RestController
+import zipbap.app.api.auth.resolver.UserInjection
 import zipbap.app.api.category.docs.CategoryDocs
 import zipbap.app.api.category.dto.CategoryResponseDto
 import zipbap.app.api.category.service.CategoryService
@@ -11,7 +13,7 @@ class CategoryController(
     private val categoryService: CategoryService
 ) : CategoryDocs {
 
-    override fun getAllCategories(userId: Long): ApiResponse<CategoryResponseDto.CategoryListResponseDto> =
-        ApiResponse.onSuccess(categoryService.getAllCategories(userId))
-    // TODO: 추후 JWT 적용 시 userId 파라미터 제거 후, SecurityContext 에서 인증 사용자 정보 추출 예정
+    override fun getAllCategories(@UserInjection user: User ):
+            ApiResponse<CategoryResponseDto.CategoryListResponseDto> =
+        ApiResponse.onSuccess(categoryService.getAllCategories(user.id!!))
 }

--- a/src/main/kotlin/zipbap/app/api/category/docs/CategoryDocs.kt
+++ b/src/main/kotlin/zipbap/app/api/category/docs/CategoryDocs.kt
@@ -1,20 +1,23 @@
 package zipbap.app.api.category.docs
 
 import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestParam
+import zipbap.app.api.auth.resolver.UserInjection
 import zipbap.app.api.category.dto.CategoryResponseDto
+import zipbap.app.domain.user.User
 import zipbap.app.global.ApiResponse
 
 @Tag(name = "Category", description = "카테고리 통합 조회 API")
 interface CategoryDocs {
 
-    @Operation(summary = "모든 카테고리 조회", description = "모든 카테고리 정보를 조회합니다. (내 카테고리는 userId 기준)")
+    @Operation(
+        summary = "모든 카테고리 조회",
+        description = "모든 카테고리 정보를 조회합니다. (내 카테고리는 JWT userId 기준)"
+    )
     @ApiResponses(
         io.swagger.v3.oas.annotations.responses.ApiResponse(
             responseCode = "200",
@@ -22,9 +25,8 @@ interface CategoryDocs {
             content = [Content(schema = Schema(implementation = CategoryResponseDto.CategoryListResponseDto::class))]
         )
     )
-    @GetMapping("/categories")
+    @GetMapping("/api/categories")
     fun getAllCategories(
-        @Parameter(description = "사용자 ID", example = "1")
-        @RequestParam userId: Long
+        @UserInjection user: User
     ): ApiResponse<CategoryResponseDto.CategoryListResponseDto>
 }

--- a/src/main/kotlin/zipbap/app/api/mycategory/controller/MyCategoryController.kt
+++ b/src/main/kotlin/zipbap/app/api/mycategory/controller/MyCategoryController.kt
@@ -2,9 +2,11 @@ package zipbap.app.api.mycategory.controller
 
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.*
+import zipbap.app.api.auth.resolver.UserInjection
 import zipbap.app.api.mycategory.dto.MyCategoryRequestDto
 import zipbap.app.api.mycategory.dto.MyCategoryResponseDto
 import zipbap.app.api.mycategory.service.MyCategoryService
+import zipbap.app.domain.user.User
 import zipbap.app.global.ApiResponse
 
 @RestController
@@ -17,32 +19,28 @@ class MyCategoryController(
     @PostMapping
     fun createMyCategory(
         @RequestBody dto: MyCategoryRequestDto.CreateMyCategoryDto,
-        @RequestParam("userId") userId: Long
+        @UserInjection user: User
     ): ApiResponse<MyCategoryResponseDto> =
-        ApiResponse.onSuccess(myCategoryService.createMyCategory(dto, userId))
-    // TODO: 추후 JWT 적용 시 userId 파라미터 제거 후, SecurityContext 에서 인증 사용자 정보 추출 예정
+        ApiResponse.onSuccess(myCategoryService.createMyCategory(dto, user.id!!))
 
     @PutMapping("/{id}")
     fun updateMyCategory(
         @PathVariable("id") id: String,
         @RequestBody dto: MyCategoryRequestDto.UpdateMyCategoryDto,
-        @RequestParam("userId") userId: Long
+        @UserInjection user: User
     ): ApiResponse<MyCategoryResponseDto> =
-        ApiResponse.onSuccess(myCategoryService.updateMyCategory(id, dto, userId))
-    // TODO: 추후 JWT 적용 시 userId 파라미터 제거 후, SecurityContext 에서 인증 사용자 정보 추출 예정
+        ApiResponse.onSuccess(myCategoryService.updateMyCategory(id, dto, user.id!!))
 
     @GetMapping
     fun getMyCategories(
-        @RequestParam("userId") userId: Long
+        @UserInjection user: User
     ): ApiResponse<List<MyCategoryResponseDto>> =
-        ApiResponse.onSuccess(myCategoryService.getMyCategories(userId))
-    // TODO: 추후 JWT 적용 시 userId 파라미터 제거 후, SecurityContext 에서 인증 사용자 정보 추출 예정
+        ApiResponse.onSuccess(myCategoryService.getMyCategories(user.id!!))
 
     @DeleteMapping("/{id}")
     fun deleteMyCategory(
         @PathVariable("id") id: String,
-        @RequestParam("userId") userId: Long
+        @UserInjection user: User
     ): ApiResponse<Unit> =
-        ApiResponse.onSuccess(myCategoryService.deleteMyCategory(id, userId))
-    // TODO: 추후 JWT 적용 시 userId 파라미터 제거 후, SecurityContext 에서 인증 사용자 정보 추출 예정
+        ApiResponse.onSuccess(myCategoryService.deleteMyCategory(id, user.id!!))
 }

--- a/src/main/kotlin/zipbap/app/api/recipe/controller/RecipeController.kt
+++ b/src/main/kotlin/zipbap/app/api/recipe/controller/RecipeController.kt
@@ -1,10 +1,12 @@
 package zipbap.app.api.recipe.controller
 
 import org.springframework.web.bind.annotation.RestController
+import zipbap.app.api.auth.resolver.UserInjection
 import zipbap.app.api.recipe.docs.RecipeDocs
 import zipbap.app.api.recipe.dto.RecipeRequestDto
 import zipbap.app.api.recipe.dto.RecipeResponseDto
 import zipbap.app.api.recipe.service.RecipeService
+import zipbap.app.domain.user.User
 import zipbap.app.global.ApiResponse
 
 @RestController
@@ -13,36 +15,31 @@ class RecipeController(
 ) : RecipeDocs {
 
     override fun createTempRecipe(
-        userId: Long
+        @UserInjection user: User
     ): ApiResponse<RecipeResponseDto.TempRecipeDetailResponseDto> =
-        ApiResponse.onSuccess(recipeService.createTempRecipe(userId))
-    // TODO: 추후 JWT 적용 시 userId 파라미터 제거 후, SecurityContext 에서 인증 사용자 정보 추출 예정
+        ApiResponse.onSuccess(recipeService.createTempRecipe(user.id!!))
 
     override fun updateTempRecipe(
         recipeId: String,
-        userId: Long,
+        @UserInjection user: User,
         request: RecipeRequestDto.UpdateTempRecipeRequestDto
     ): ApiResponse<RecipeResponseDto.TempRecipeDetailResponseDto> =
-        ApiResponse.onSuccess(recipeService.updateTempRecipe(request, userId, recipeId))
-    // TODO: 추후 JWT 적용 시 userId 파라미터 제거 후, SecurityContext 에서 인증 사용자 정보 추출 예정
+        ApiResponse.onSuccess(recipeService.updateTempRecipe(request, user.id!!, recipeId))
 
     override fun finalizeRecipe(
         recipeId: String,
-        userId: Long,
+        @UserInjection user: User,
         request: RecipeRequestDto.FinalizeRecipeRequestDto
     ): ApiResponse<RecipeResponseDto.RecipeDetailResponseDto> =
-        ApiResponse.onSuccess(recipeService.finalizeRecipe(recipeId, userId, request))
-    // TODO: 추후 JWT 적용 시 userId 파라미터 제거 후, SecurityContext 에서 인증 사용자 정보 추출 예정
+        ApiResponse.onSuccess(recipeService.finalizeRecipe(recipeId, user.id!!, request))
 
     override fun getMyTempRecipes(
-        userId: Long
+        @UserInjection user: User
     ): ApiResponse<List<RecipeResponseDto.TempRecipeDetailResponseDto>> =
-        ApiResponse.onSuccess(recipeService.getMyTempRecipes(userId))
-    // TODO: 추후 JWT 적용 시 userId 파라미터 제거 후, SecurityContext 에서 인증 사용자 정보 추출 예정
+        ApiResponse.onSuccess(recipeService.getMyTempRecipes(user.id!!))
 
     override fun getMyRecipes(
-        userId: Long
+        @UserInjection user: User
     ): ApiResponse<List<RecipeResponseDto.RecipeDetailResponseDto>> =
-        ApiResponse.onSuccess(recipeService.getMyRecipes(userId))
-    // TODO: 추후 JWT 적용 시 userId 파라미터 제거 후, SecurityContext 에서 인증 사용자 정보 추출 예정
+        ApiResponse.onSuccess(recipeService.getMyRecipes(user.id!!))
 }

--- a/src/main/kotlin/zipbap/app/api/recipe/converter/RecipeConverter.kt
+++ b/src/main/kotlin/zipbap/app/api/recipe/converter/RecipeConverter.kt
@@ -50,6 +50,7 @@ object RecipeConverter {
         Recipe(
             id = id,
             user = user,
+            thumbnail = dto.thumbnail,
             title = dto.title,
             subtitle = dto.subtitle,
             introduction = dto.introduction,
@@ -114,6 +115,7 @@ object RecipeConverter {
     ): RecipeResponseDto.RecipeDetailResponseDto =
         RecipeResponseDto.RecipeDetailResponseDto(
             id = recipe.id,
+            thumbnail = recipe.thumbnail!!,
             title = recipe.title!!,
             subtitle = recipe.subtitle!!,
             introduction = recipe.introduction!!,
@@ -147,6 +149,7 @@ object RecipeConverter {
     ): RecipeResponseDto.TempRecipeDetailResponseDto =
         RecipeResponseDto.TempRecipeDetailResponseDto(
             id = recipe.id,
+            thumbnail = recipe.thumbnail,
             title = recipe.title,
             subtitle = recipe.subtitle,
             introduction = recipe.introduction,

--- a/src/main/kotlin/zipbap/app/api/recipe/docs/RecipeDocs.kt
+++ b/src/main/kotlin/zipbap/app/api/recipe/docs/RecipeDocs.kt
@@ -5,26 +5,19 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.*
+import zipbap.app.api.auth.resolver.UserInjection
 import zipbap.app.api.recipe.dto.RecipeRequestDto
 import zipbap.app.api.recipe.dto.RecipeResponseDto
+import zipbap.app.domain.user.User
 import zipbap.app.global.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
 
 @RequestMapping("/api/recipes")
 @Tag(name = "Recipe", description = "레시피 관련 API")
 interface RecipeDocs {
 
-    @Operation(
-        summary = "임시 레시피 생성",
-        description = "사용자가 임시 저장용 레시피를 생성합니다. 필수값만 채워지고 나머지는 null 처리됩니다. (JWT 적용 전까지는 userId 파라미터 사용)"
-    )
+    @Operation(summary = "임시 레시피 생성", description = "사용자가 임시 저장용 레시피를 생성합니다.")
     @ApiResponses(
         SwaggerApiResponse(
             responseCode = "200",
@@ -34,13 +27,10 @@ interface RecipeDocs {
     )
     @PostMapping("/temp")
     fun createTempRecipe(
-        @RequestParam("userId") userId: Long
+        @UserInjection user: User
     ): ApiResponse<RecipeResponseDto.TempRecipeDetailResponseDto>
 
-    @Operation(
-        summary = "임시 레시피 업데이트",
-        description = "임시 저장된 레시피를 수정합니다. 조리 순서를 null로 보내면 기존 순서를 유지하고, []로 보내면 전체 삭제 후 교체합니다. 최종 저장은 /{recipeId}/finalize 사용. (JWT 적용 전까지는 userId 파라미터 사용)"
-    )
+    @Operation(summary = "임시 레시피 업데이트", description = "임시 저장된 레시피를 수정합니다. 최종 저장은 /{recipeId}/finalize 사용.")
     @ApiResponses(
         SwaggerApiResponse(
             responseCode = "200",
@@ -51,14 +41,11 @@ interface RecipeDocs {
     @PutMapping("/{recipeId}/temp")
     fun updateTempRecipe(
         @PathVariable("recipeId") recipeId: String,
-        @RequestParam("userId") userId: Long,
+        @UserInjection user: User,
         @RequestBody request: RecipeRequestDto.UpdateTempRecipeRequestDto
     ): ApiResponse<RecipeResponseDto.TempRecipeDetailResponseDto>
 
-    @Operation(
-        summary = "레시피 작성(최종 저장)",
-        description = "임시 레시피를 최종 저장(활성화)합니다. 모든 필드가 필수이며 카테고리 유효성 검증을 통과해야 합니다. (JWT 적용 전까지는 userId 파라미터 사용)"
-    )
+    @Operation(summary = "레시피 작성(최종 저장)", description = "임시 레시피를 최종 저장합니다. 모든 필드가 필수.")
     @ApiResponses(
         SwaggerApiResponse(
             responseCode = "200",
@@ -69,15 +56,11 @@ interface RecipeDocs {
     @PutMapping("/{recipeId}/finalize")
     fun finalizeRecipe(
         @PathVariable("recipeId") recipeId: String,
-        @RequestParam("userId") userId: Long,
+        @UserInjection user: User,
         @RequestBody request: RecipeRequestDto.FinalizeRecipeRequestDto
     ): ApiResponse<RecipeResponseDto.RecipeDetailResponseDto>
 
-
-    @Operation(
-        summary = "내 임시 레시피 전체 조회",
-        description = "사용자의 모든 임시 저장 레시피를 조회합니다. (JWT 적용 전까지는 userId 파라미터 사용)"
-    )
+    @Operation(summary = "내 임시 레시피 전체 조회", description = "사용자의 모든 임시 저장 레시피를 조회합니다.")
     @ApiResponses(
         SwaggerApiResponse(
             responseCode = "200",
@@ -87,13 +70,10 @@ interface RecipeDocs {
     )
     @GetMapping("/temp")
     fun getMyTempRecipes(
-        @RequestParam("userId") userId: Long
+        @UserInjection user: User
     ): ApiResponse<List<RecipeResponseDto.TempRecipeDetailResponseDto>>
 
-    @Operation(
-        summary = "내 완성된 레시피 전체 조회",
-        description = "사용자의 모든 최종 저장(완성) 레시피를 조회합니다. (JWT 적용 전까지는 userId 파라미터 사용)"
-    )
+    @Operation(summary = "내 완성된 레시피 전체 조회", description = "사용자의 모든 완성 레시피를 조회합니다.")
     @ApiResponses(
         SwaggerApiResponse(
             responseCode = "200",
@@ -103,6 +83,6 @@ interface RecipeDocs {
     )
     @GetMapping
     fun getMyRecipes(
-        @RequestParam("userId") userId: Long
+        @UserInjection user: User
     ): ApiResponse<List<RecipeResponseDto.RecipeDetailResponseDto>>
 }

--- a/src/main/kotlin/zipbap/app/api/recipe/dto/RecipeRequestDto.kt
+++ b/src/main/kotlin/zipbap/app/api/recipe/dto/RecipeRequestDto.kt
@@ -13,6 +13,9 @@ object RecipeRequestDto {
      */
     data class FinalizeRecipeRequestDto(
 
+        @Schema(description = "대표 썸네일 URL", example = "https://cdn.zipbap.store/recipes/thumbnail.jpg", required = true)
+        val thumbnail: String,
+
         @Schema(description = "레시피 제목", example = "소고기 미역국", required = true)
         val title: String,
 
@@ -79,6 +82,9 @@ object RecipeRequestDto {
      * 모든 필드 선택값(null 허용)
      */
     data class UpdateTempRecipeRequestDto(
+
+        @Schema(description = "대표 썸네일 URL", example = "https://cdn.zipbap.store/recipes/thumbnail.jpg", required = false)
+        val thumbnail: String,
 
         @Schema(description = "레시피 제목", example = "소고기 미역국", required = false)
         val title: String? = null,

--- a/src/main/kotlin/zipbap/app/api/recipe/dto/RecipeResponseDto.kt
+++ b/src/main/kotlin/zipbap/app/api/recipe/dto/RecipeResponseDto.kt
@@ -15,6 +15,9 @@ object RecipeResponseDto {
         @Schema(description = "레시피 제목", example = "소고기 미역국")
         val title: String,
 
+        @Schema(description = "대표 썸네일 URL", example = "https://cdn.zipbap.store/recipes/thumbnail.jpg")
+        val thumbnail: String,
+
         @Schema(description = "레시피 소제목", example = "할머니의 손맛")
         val subtitle: String,
 
@@ -79,6 +82,9 @@ object RecipeResponseDto {
 
         @Schema(description = "레시피 ID", example = "RC-1-00002")
         val id: String,
+
+        @Schema(description = "대표 썸네일 URL", example = "https://cdn.zipbap.store/recipes/temp_thumbnail.jpg")
+        val thumbnail: String? = null,
 
         @Schema(description = "레시피 제목", example = "임시 소고기 미역국")
         val title: String? = null,

--- a/src/main/kotlin/zipbap/app/api/recipe/service/RecipeService.kt
+++ b/src/main/kotlin/zipbap/app/api/recipe/service/RecipeService.kt
@@ -2,7 +2,6 @@ package zipbap.app.api.recipe.service
 
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import zipbap.app.api.file.service.PresignedUrlProvider
 import zipbap.app.api.recipe.converter.RecipeConverter
 import zipbap.app.api.recipe.dto.RecipeRequestDto
 import zipbap.app.api.recipe.dto.RecipeResponseDto
@@ -71,6 +70,7 @@ class RecipeService(
 
         // 레시피 기본 필드 업데이트
         recipe.apply {
+            thumbnail = dto.thumbnail ?: thumbnail
             title = dto.title ?: title
             subtitle = dto.subtitle ?: subtitle
             introduction = dto.introduction ?: introduction
@@ -119,6 +119,7 @@ class RecipeService(
 
         // 레시피 엔티티 업데이트
         recipe.apply {
+            thumbnail = dto.thumbnail
             title = dto.title
             subtitle = dto.subtitle
             introduction = dto.introduction

--- a/src/main/kotlin/zipbap/app/domain/recipe/Recipe.kt
+++ b/src/main/kotlin/zipbap/app/domain/recipe/Recipe.kt
@@ -20,6 +20,9 @@ class Recipe(
         @JoinColumn(name = "user_id", nullable = false)
         val user: User,
 
+        @Column(length = 200, nullable = true)
+        var thumbnail: String? = null,
+
         @Column(nullable = true, length = 100)
         var title: String? = null,
 


### PR DESCRIPTION
### 변경 사항
- **auth**
  - userId 파라미터 제거 → @UserInjection 기반 인증 사용자 자동 주입
  - JWT 토큰 구조 변경 (userId → sub 기반)
  - 관련 서비스 로직 리팩토링

- **recipe**
  - Recipe 엔티티 및 API에 thumbnail 필드 추가

### 효과
- 보안 강화: userId 파라미터 변조 방지
- API 명세 단순화: Swagger 문서에서 userId 파라미터 제거
- 인증 흐름 일관성 확보 (SecurityContext → User 주입)
- 레시피 조회 시 썸네일 활용 가능
